### PR TITLE
remove blue background on link clicks in mobile devices

### DIFF
--- a/play/static/play/styles/base.css
+++ b/play/static/play/styles/base.css
@@ -293,6 +293,10 @@ footer .copyright {
     max-height: unset !important;
   }
 
+  * {
+    -webkit-tap-highlight-color: transparent;
+  }
+
 }
 
 @media screen and (max-width: 900px) {

--- a/play/static/play/styles/watch.css
+++ b/play/static/play/styles/watch.css
@@ -614,8 +614,4 @@ video {
     line-height: 1.4em;
   }
 
-  * {
-    -webkit-tap-highlight-color: transparent;
-  }
-
 }


### PR DESCRIPTION
Removed the blue background default behaviour when clicked on image links or other elements wrapped inside anchor tags on mobile devices.