### PR TITLE
feat: Add visibility checks for private videos

### DIFF
--- a/play/api/views.py
+++ b/play/api/views.py
@@ -32,6 +32,13 @@ def logo(request):
 @api_view(['GET'])
 def getVideoStream(request, video_id, file):
     video = Video.objects.get(video_id=video_id)
+    # visibility checks
+    if video.visibility == 'private':
+        if request.user.is_anonymous:
+            return Response(status=401)
+        if request.user.channel != video.channel:
+            return Response(status=403)
+
     video_path = video.video_file.path
     stream_path = os.path.join(os.path.dirname(video_path), file)
     try:

--- a/play/views.py
+++ b/play/views.py
@@ -43,7 +43,7 @@ def logoutPage(request):
 def home(request):
     # check if play_video table is empty without using count()
     if Video.objects.exists():
-        videos = Video.objects.all()
+        videos = Video.objects.all().filter(visibility='public')
         # shuffle the videos
         videos = videos.order_by('?')
 
@@ -128,6 +128,14 @@ def watch(request):
         return render(request, 'play/404.html', info, status=404)
     try:
         video = Video.objects.get(video_id=video_id)
+        # visibility check
+        if video.visibility == 'private':
+            if not request.user.is_authenticated:
+                return redirect('play:login')
+            if request.user.channel != video.channel:
+                info = {'info': 'This video is private and can only be viewed by the channel owner'}
+                return render(request, 'play/404.html', info, status=404)
+
         channel_id = video.channel.channel_id if channel_id is None else channel_id
         channel = Channel.objects.get(
             channel_id=channel_id) if channel_id is not None else None


### PR DESCRIPTION
Adds visibility checks for private videos in the `getVideoStream` and `watch` views. If a video is marked as private, only authenticated users who are the channel owner can access it. Otherwise, a 401 or 403 response is returned accordingly.